### PR TITLE
Fix anti-aliased edges stencil test

### DIFF
--- a/src/renderer/webgpu.rs
+++ b/src/renderer/webgpu.rs
@@ -30,29 +30,11 @@ mod wgpu_var;
 pub use wgpu_var::*;
 
 use crate::{
-    renderer::{
-        ImageId,
-        Vertex,
-    },
-    BlendFactor,
-    Color,
-    CompositeOperationState,
-    ErrorKind,
-    FillRule,
-    ImageInfo,
-    ImageSource,
-    ImageStore,
-    Rect,
-    Size,
+    renderer::{ImageId, Vertex},
+    BlendFactor, Color, CompositeOperationState, ErrorKind, FillRule, ImageInfo, ImageSource, ImageStore, Rect, Size,
 };
 
-use super::{
-    Command,
-    CommandType,
-    Params,
-    RenderTarget,
-    Renderer,
-};
+use super::{Command, CommandType, Params, RenderTarget, Renderer};
 
 use self::VecExt;
 
@@ -1007,6 +989,7 @@ impl Renderer for WGPU {
                             // let bg = bind_group!(self, images, cmd.image, cmd.alpha_mask);
                             {
                                 pass.set_pipeline(s.aa_pixels());
+                                pass.set_stencil_reference(0);
                                 pass.set_bind_group(0, bg.as_ref(), &[uniforms_offset]);
                                 uniforms_offset += std::mem::size_of::<Params>() as u32;
                             }

--- a/src/renderer/webgpu/wgpu_pipeline_cache.rs
+++ b/src/renderer/webgpu/wgpu_pipeline_cache.rs
@@ -2,13 +2,7 @@ use std::collections::HashMap;
 
 use crate::BlendFactor;
 
-use super::{
-    Color,
-    Rect,
-    Vertex,
-    WGPUBlend,
-    WGPUContext,
-};
+use super::{Color, Rect, Vertex, WGPUBlend, WGPUContext};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct PipelineCacheKey {
@@ -406,7 +400,7 @@ fn stroke_anti_alias_stencil_state(format: wgpu::TextureFormat) -> wgpu::DepthSt
         depth_compare: wgpu::CompareFunction::Always,
         stencil: wgpu::StencilState {
             front: wgpu::StencilFaceState {
-                // compare: wgpu::CompareFunction::NotEqual,
+                compare: wgpu::CompareFunction::Equal,
                 // fail_op: wgpu::StencilOperation::Zero,
                 // depth_fail_op: wgpu::StencilOperation::Zero,
                 // pass_op: wgpu::StencilOperation::Keep,


### PR DESCRIPTION
The stencil AA pass wasn't properly using the stencil buffer to render smoothed edges. It used to draw all over the shape when it should only be visible "outside".

Before:
![image](https://user-images.githubusercontent.com/11479594/114449250-d55dd300-9bd4-11eb-8f5d-74d477f50ddc.png)

After:
![image](https://user-images.githubusercontent.com/11479594/114449357-f0304780-9bd4-11eb-9286-f9de41a7f870.png)

This also caused the shape to be much darker than it should!